### PR TITLE
Adding methods from api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,12 @@ php:
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev
-  - travis_retry pyrus install pear/PHP_CodeSniffer
   - travis_retry phpenv rehash
 
 script:
-  - phpcs --standard=psr2 src/
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - ./vendor/bin/phpcs --standard=psr2 src/
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-
-matrix:
-  allow_failures:
-    - php: 7.0
-    - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 All Notable changes to `jobs-careerbuilder` will be documented in this file
 
+## 1.0.0 - 2015-09-XX
+
+### Added
+- Support for all setter methods outlined in the [Careerbuilder API](http://api.careerbuilder.com/Search/jobsearch/jobsearchinfo.aspx)
+- Readme documentation for all supported methods
+- Tests to support all new methods
+
+### Deprecated
+- Public methods for parsing range/fixed salaries made protected
+
+### Fixed
+- Sorting methods alphabetically
+
+### Removed
+- Public "getSkillSet" replaced with protected "parseSkillSet" method
+
+### Security
+- Nothing
+
 ## 0.2.0 - 2015-09-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All Notable changes to `jobs-careerbuilder` will be documented in this file
 
 ### Fixed
 - Sorting methods alphabetically
+- Travis-ci support for PHP 7.0 and HHVM
 
 ### Removed
 - Public "getSkillSet" replaced with protected "parseSkillSet" method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All Notable changes to `jobs-careerbuilder` will be documented in this file
 
-## 1.0.0 - 2015-09-XX
+## 1.0.0 - 2015-09-27
 
 ### Added
 - Support for all setter methods outlined in the [Careerbuilder API](http://api.careerbuilder.com/Search/jobsearch/jobsearchinfo.aspx)

--- a/README.md
+++ b/README.md
@@ -24,15 +24,87 @@ Usage is the same as Job Branders's Jobs Client, using `\JobBrander\Jobs\Client\
 
 ```php
 $client = new JobBrander\Jobs\Client\Provider\Careerbuilder([
-    'developerKey' => 'YOUR CAREERBUILDER DEVELOPER KEY'
+    'DeveloperKey' => 'YOUR CAREERBUILDER DEVELOPER KEY'
 ]);
 
 // Search for 200 job listings for 'project manager' in Chicago, IL
-$jobs = $client->setKeyword('engineer') // Can accept a single value, or a comma-separated list of values. Will return a results set that is related to the supplied keywords.
-    ->setCity('Pasadena')          // Accepts a comma-separated list of Cities and will limit the job search to that area.
-    ->setState('CA')               // Accepts a comma-separated list of denoted two letter State values and will limit the job search to that area.
-    ->setPage(2)                   // The page of listings to return. Defaults to 1.
-    ->setCount(20)                 // The number of listings per page. The default value is 10. The maximum value is 100.
+$jobs = $client
+    // API Parameters
+    ->setHostSite('US')             // Two-character code for property being searched. Defaults to 'US'.
+    ->setDeveloperKey()    // Required. 20 character long CB API Developer Key.
+    ->setAdvancedGroupingMode()    // Optional. Defaults to false. If true, tailors the response format for a grouped search by providing additional grouping metadata. Will only take effect if EnableCompanyCollapse=true or EnableCompanyJobTitleCollapse=true.
+    ->setApplyRequirements()    // Optional. Accepts a CSV string value. Limit the search to specific applying requirements. Current valid values: isexternal, canbulkapply, requireuserinfo, hasscreener, hasaoreview, and noonlineapply
+    ->setBooleanOperator()    // Optional. Can accept a single value only. Use this param to set change how the keywords are joined together. If no value is provided, defaults to AND. Valid values are: AND, OR.
+    ->setCategory()    // Optional. Can accept a single value, or a comma-separated list of values (maximum 10). If the given value(s) do not match any of CareeerBuilder's category names or category codes, this parameter is ignored. We do not attempt any partial matching. Reference the Categories service for a complete list of valid category names and codes. Note to internal CB developers: This parameter also accepts channel codes.
+    ->setCoBrand()    // Optional. Some of our existing partners use this param for tracking purposes. If you don't already know what this is, don't worry about it.
+    ->setCompanyDID()    // Optional. Accepts a single value. Will limit the Job Search to jobs from the supplied CompanyDID.
+    ->setCompanyDIDCSV()    // Optional. Will limit the Job Search to jobs from the supplied CompanyDIDs.
+    ->setCompanyName()    // Optional. Accepts a single value. Will limit the Job Search to companies whose names contain the value provided. Use quote-marks if you have multiple words with spaces and want to match the exact string
+    ->setCompanyNameBoostParams()    // Optional. Accepts formatted name/weight pairs. Maximum boost weight = 10000, minimum boost weight = 0. Sets company names that the search should favor. Given in this format: companyname1^600~companyname2^400~companyname3^1000.
+    ->setCountryCode()    // Optional. Accepts a single two-character value. Will limit the Job Search to the given country.
+    ->setEducationCode()    // Optional. Accepts a single value. If the given value does not match one of CareeerBuilder's education codes, this parameter is ignored. By default search results will include results with the requested education code or lower, use the SpecificEducation parameter. Reference the EducationCodes service for a complete list of valid education codes.
+    ->setEmpType()    // Optional. Can accept a single value, or a comma-separated list of values. Valid values are variable, depending on what country is being searched. Reference the Employee Types service for a complete list of valid employee types.
+    ->setEnableCompanyCollapse()    // Optional. If true, the search results will return grouped by company. This is considered simple grouping mode; the format of the results will not be changed, and no additional metadata about the groups will be returned.
+    ->setEnableCompanyJobTitleCollapse()    // Optional. If true, the search results will return grouped by company job title. This is considered simple grouping mode; the format of the results will not be changed, and no additional metadata about the groups will be returned.
+    ->setExcludeApplyRequirements()    // Optional. Accepts a CSV string value. Limit the search to exclude specific applying requirements. See ApplyRequirements for valid values.
+    ->setExcludeCompanyNames()    // Optional. Accepts a single value or list of comma-separated values. Will limit the Job Search to companies whose names not contain the value(s) provided. Use quote-marks if you have multiple words with spaces and want to match the exact string.
+    ->setExcludeJobTitles()    // Optional. Accepts a CSV of job titles. Will limit the Job Search to titles whose names DO NOT contain the values provided. Use quote-marks if you have multiple words with spaces and want to match the exact string.
+    ->setExcludeKeywords()    // Optional. Can accept a single value, or a comma-separated list of values. Excludes results that are related to the provided value(s).
+    ->setExcludeNational()    // Optional. If true, excludes jobs that have been posted as "nationwide".
+    ->setExcludeNonTraditionalJobs()    // Optional. If true, will exclude jobs that have been marked as nontraditional.
+    ->setFacetCategory()    // Optional. *UseFacets must be set to true for this to be considered* Accepts a comma-separated list of Job Category values. Will limit the job search to jobs that fall under a particulair category. Acceptable Job Categories codes (http://api.careerbuilder.com/v1/categories)
+    ->setFacetCompany()    // Optional. *UseFacets must be set to true for this to be considered* Only accepts a single Company Title that must be encased in double quotes ("Company Name"). Will limit the job search to a particulair company.
+    ->setFacetCity()    // Optional. *UseFacets must be set to true for this to be considered* Accepts a comma-separated list of Cities and will limit the job search to that area.
+    ->setFacetState()    // Optional. *UseFacets must be set to true for this to be considered* Accepts a comma-separated list of denoted two letter State values and will limit the job search to that area.
+    ->setFacetCityState()    // Optional. *UseFacets must be set to true for this to be considered* Only accepts a single value in the form of a City and denoted two letter State value delimited by a comma. This will limit the job search to that area.
+    ->setFacetPay()    // Optional. *UseFacets must be set to true for this to be considered* Accepts a single value from the following list:
+    ->setFacetRelatedJobTitle()    // Optional. *UseFacets must be set to true for this to be considered* Only accepts a single Job Title. This will limit the job search to return jobs that are categorized under the same/related job title(s).
+    ->setFacetCountry()    // Optional. *UseFacets must be set to true for this to be considered* Accepts a list of values in the form of a two letter country code. This will limit the job search to that area.
+    ->setFacetEmploymentType()    // Optional. *UseFacets must be set to true for this to be considered* Accepts a comma-separated list of values in the form of an employment type. This will limit the job search to that area.
+    ->setIncludeCompanyChildren()    // Optional. If true, the result set will also contain jobs from child companies of the specified company given in the CompanyName, CompanyNameCSV, or CompanyDID params.
+    ->setIndustryCodes()    // Optional. Accepts a CSV. Will limit the Job Search to only jobs in the given industries. Accepts a CSV of values returned from v1/industrycodes.
+    ->setJobTitle()    // Optional. Accepts a single value. Will return only jobs with the provided job title in their title. Use quote-marks if you have multiple words with spaces and want to match the exact string.
+    ->setKeywords()    // Optional. Can accept a single value, or a comma-separated list of values. Will return a results set that is related to the supplied keywords.
+    ->setLocation()    // Optional. Can accept a single city name, a single state name, a postal code (as in: 30092), a comma-separated city/state pair (as in: Atlanta, GA), or a latitude and longitude in decimal degree (DD) format (as in 36.7636::-119.7746). If the given location is ambiguous, a list of possible locations will be returned.
+    ->setNormalizedCompanyDID()    // Optional. Accepts a single value. Will limit the Job Search to only jobs whose owning companies have been normalized to the given normalized company DID.
+    ->setNormalizedCompanyDIDBoostParams()    // Optional. Accepts formatted normalized company DID/weight pairs. Maximum boost weight = 10000, minimum boost weight = 0. Sets normalized companies that the search should favor. Given in this format: normalizedcompanyDID1^600~normalizedcompanyDID2^4000.
+    ->setNormalizedCompanyName()    // Optional. Accepts a single value. Will limit the Job Search to only jobs whose owning companies have been normalized to the given normalized company name.
+    ->setONetCode()    // Optional. Accepts a single value or CSV; refer to the notes for SingleONetSearch for details about CSV. Will limit the Job Search to jobs related to the given ONet Code. Searches on Major Group, Minor Group, Broad Occupation and Detailed Occuptation. More specific matches are ranked as more relevant in the results. Information about ONet codes
+    ->setOrderBy()    // Optional. Can accept a single value only. Use this param to set the ordering of the results. If no value is provided, defaults to Relevance. Valid values are: Date, Pay, Title, Company, Distance, Location, and Relevance. Note: Ordering by Date does not ensure strict date ordering.
+    ->setOrderDirection()    // Optional. Can accept a single value only. Use this param to set the direction of the results order. If no value is provided, defaults to descending (generally best to worst). Valid values are: Ascending, ASC, Descending, DESC. Note: Ordering by distance defaults to ascending (nearest to farthest).
+    ->setPageNumber()    // Optional. Can accept a single value only. Use this param to retrieve a specific page of results.
+    ->setPartnerID()    // Optional. Accepts a single value. Will limit the Job Search to only jobs that fall under the given partner ID.
+    ->setPayHigh()    // Optional. This can be used to set a maximum pay level for the search. Values that are acceptable are those that appear on the main CareerBuilder site's advanced job search form.
+    ->setPayInfoOnly()    // Optional. If true, then the search results will contain only jobs with pay information.
+    ->setPayLow()    // Optional. This can be used to set a minimum pay level for the search. Values that are acceptable are those that appear on the main CareerBuilder site's advanced job search form.
+    ->setPerPage()    // Optional. Can accept a single value only. Use this param to set the page size. If no value is provided, defaults to 25.
+    ->setPostedWithin()    // Optional. Can accept a single value only. Must be no greater than 30. If no value is provided, defaults to 30. Filters the results list to contain only jobs posted with the provided number of days.
+    ->setRadius()    // Optional. The search radius size (in miles) around a specified location. Acceptable values are 5, 10, 20, 30, 50, 100, or 150. A radius of 0 is treated the same as empty. The radius will be the default for the search geography.
+    ->setRecordsPerGroup()    // Optional. Sets the number of results per group to return if the search is set to run in either simple or advanced grouping mode. Will have only take effect if EnableCompanyCollapse=true.
+    ->setRelocateJobs()    // Optional. If supplied, returns jobs marked 'true' or 'false' for providing relocation assistance. If not supplied, then we search for jobs with 'null' data for relocation assistance (most jobs fall into this category).
+    ->setSOCCode()    // Optional. Accepts a single value. Will limit the Job Search to jobs related to the given SOC Code. Searches on Major Group, Minor Group, Broad Occupation and Detailed Occuptation. More specific matches are ranked as more relevant in the results. Information about SOC classification
+    ->setSchoolSiteID()    // Optional. Constrains the search to only return jobs marked with the given school site ID.
+    ->setSearchAllCountries()    // Optional. If true, the search will not be constrained by CountryCode or HostSite.
+    ->setSearchView()    // Optional. Sets the view context in which the search should run.
+    ->setShowCategories()    // Optional. If true, a Categories node will be inserted into the response showing which categories each search result was posted under.
+    ->setShowApplyRequirements()    // Optional. If true, a ApplyRequirements node will be inserted into the response showing what are required info for applying.
+    ->setSingleONetSearch()    // Optional. Will limit the Job Search to jobs marked with the exact given ONet code(s) in the ONetCode parameter. Turns the ONetCode parameter into a CSV. Searches on the exact ONet code(s) ONLY. Information about ONet codes
+    ->setSiteEntity()    // Optional. Accepts a single value. Configures the job search with the given site entity.
+    ->setSiteID()    // Optional. Some of our existing partners use this param for tracking purposes. If you don't already know what this is, don't worry about it.
+    ->setSkills()    // Optional. Accepts a single value or a comma-separated list of values. Filters the search results to contain only jobs marked with the given skills.
+    ->setSpecificEducation()    // Optional. If set to true, it will only return results with exactly the EducationCode parameter provided. >If no EducationCode parameter is provided, this parameter is ignored.
+    ->setSpokenLanguage()    // Optional. Accepts one of the folowing values ENG (English), FRA (French) or NLD (Dutch)
+    ->setTags()    // Optional. Accepts a CSV. Will limit the Job Search to only jobs that are marked with the given tags.
+    ->setTalentNetworkDID()    // Optional. Returns jobs that have been marked as part of a given Talent Network.
+    ->setUrlCompressionService()    // Optional. Configures a URL compression service to use when constructing links. Accepts bitly or tinyurl.
+    ->setUseFacets()    // Optional. If true, a set of facets describing the search results is returned in addition to the set of results.
+
+    // JobBrander Parameters
+    ->setKeyword('engineer')        // Can accept a single value, or a comma-separated list of values. Will return a results set that is related to the supplied keywords.
+    ->setCity('Pasadena')           // Accepts a comma-separated list of Cities and will limit the job search to that area.
+    ->setState('CA')                // Accepts a comma-separated list of denoted two letter State values and will limit the job search to that area.
+    ->setPage(2)                    // The page of listings to return. Defaults to 1.
+    ->setCount(20)                  // The number of listings per page. The default value is 10. The maximum value is 100.
     ->getJobs();
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,10 @@
         "jobbrander/jobs-common": "~1.0.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": ">=4.6",
         "phpunit/php-code-coverage": "~2.0",
-        "mockery/mockery": ">=0.9.4"
+        "mockery/mockery": ">=0.9.4",
+        "squizlabs/php_codesniffer": "~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Careerbuilder.php
+++ b/src/Careerbuilder.php
@@ -5,32 +5,214 @@ use JobBrander\Jobs\Client\Job;
 class Careerbuilder extends AbstractProvider
 {
     /**
-     * Developer Key
+     * Default return attributes
      *
-     * @var string
+     * @var array
      */
-    protected $developerKey;
+    protected $defaultAttributes = [
+        'Company',
+        'CompanyDetailsURL',
+        'DescriptionTeaser',
+        'DID',
+        'OnetCode',
+        'ONetFriendlyTitle',
+        'EmploymentType',
+        'EducationRequired',
+        'ExperienceRequired',
+        'JobDetailsURL',
+        'Location',
+        'City',
+        'State',
+        'PostedDate',
+        'Pay',
+        'JobTitle',
+        'CompanyImageURL',
+        'Skills',
+    ];
 
     /**
-     * Host Site
+     * Map of setter methods to query parameters
      *
-     * @var string
+     * @var array
      */
-    protected $hostSite;
+    protected $queryMap = [
+        'setDeveloperKey' => 'DeveloperKey',
+        'setAdvancedGroupingMode' => 'AdvancedGroupingMode',
+        'setApplyRequirements' => 'ApplyRequirements',
+        'setBooleanOperator' => 'BooleanOperator',
+        'setCategory' => 'Category',
+        'setCity' => 'FacetCity',
+        'setCoBrand' => 'CoBrand',
+        'setCompanyDID' => 'CompanyDID',
+        'setCompanyDIDCSV' => 'CompanyDIDCSV',
+        'setCompanyName' => 'CompanyName',
+        'setCompanyNameBoostParams' => 'CompanyNameBoostParams',
+        'setCount' => 'PerPage',
+        'setCountryCode' => 'CountryCode',
+        'setEducationCode' => 'EducationCode',
+        'setEmpType' => 'EmpType',
+        'setEnableCompanyCollapse' => 'EnableCompanyCollapse',
+        'setEnableCompanyJobTitleCollapse' => 'EnableCompanyJobTitleCollapse',
+        'setExcludeApplyRequirements' => 'ExcludeApplyRequirements',
+        'setExcludeCompanyNames' => 'ExcludeCompanyNames',
+        'setExcludeJobTitles' => 'ExcludeJobTitles',
+        'setExcludeKeywords' => 'ExcludeKeywords',
+        'setExcludeNational' => 'ExcludeNational',
+        'setExcludeNonTraditionalJobs' => 'ExcludeNonTraditionalJobs',
+        'setFacetCategory' => 'FacetCategory',
+        'setFacetCompany' => 'FacetCompany',
+        'setFacetCity' => 'FacetCity',
+        'setFacetState' => 'FacetState',
+        'setFacetCityState' => 'FacetCityState',
+        'setFacetPay' => 'FacetPay',
+        'setFacetRelatedJobTitle' => 'FacetRelatedJobTitle',
+        'setFacetCountry' => 'FacetCountry',
+        'setFacetEmploymentType' => 'FacetEmploymentType',
+        'setHostSite' => 'HostSite',
+        'setIncludeCompanyChildren' => 'IncludeCompanyChildren',
+        'setIndustryCodes' => 'IndustryCodes',
+        'setJobTitle' => 'JobTitle',
+        'setKeywords' => 'Keywords',
+        'setKeyword' => 'Keywords',
+        'setLocation' => 'Location',
+        'setNormalizedCompanyDID' => 'NormalizedCompanyDID',
+        'setNormalizedCompanyDIDBoostParams' => 'NormalizedCompanyDIDBoostParams',
+        'setNormalizedCompanyName' => 'NormalizedCompanyName',
+        'setONetCode' => 'ONetCode',
+        'setOrderBy' => 'OrderBy',
+        'setOrderDirection' => 'OrderDirection',
+        'setPage' => 'PageNumber',
+        'setPageNumber' => 'PageNumber',
+        'setPartnerID' => 'PartnerID',
+        'setPayHigh' => 'PayHigh',
+        'setPayInfoOnly' => 'PayInfoOnly',
+        'setPayLow' => 'PayLow',
+        'setPerPage' => 'PerPage',
+        'setPostedWithin' => 'PostedWithin',
+        'setRadius' => 'Radius',
+        'setRecordsPerGroup' => 'RecordsPerGroup',
+        'setRelocateJobs' => 'RelocateJobs',
+        'setSOCCode' => 'SOCCode',
+        'setSchoolSiteID' => 'SchoolSiteID',
+        'setSearchAllCountries' => 'SearchAllCountries',
+        'setSearchView' => 'SearchView',
+        'setShowCategories' => 'ShowCategories',
+        'setShowApplyRequirements' => 'ShowApplyRequirements',
+        'setSingleONetSearch' => 'SingleONetSearch',
+        'setSiteEntity' => 'SiteEntity',
+        'setSiteID' => 'SiteID',
+        'setSkills' => 'Skills',
+        'setSpecificEducation' => 'SpecificEducation',
+        'setSpokenLanguage' => 'SpokenLanguage',
+        'setState' => 'FacetState',
+        'setTags' => 'Tags',
+        'setTalentNetworkDID' => 'TalentNetworkDID',
+        'setUrlCompressionService' => 'UrlCompressionService',
+        'setUseFacets' => 'UseFacets',
+    ];
 
     /**
-     * Use Facets (for city/state)
+     * Current api query parameters
      *
-     * @var string
+     * @var array
      */
-    protected $useFacets;
+    protected $queryParams = [
+        'DeveloperKey' => null,
+        'AdvancedGroupingMode' => null,
+        'ApplyRequirements' => null,
+        'BooleanOperator' => null,
+        'Category' => null,
+        'CoBrand' => null,
+        'CompanyDID' => null,
+        'CompanyDIDCSV' => null,
+        'CompanyName' => null,
+        'CompanyNameBoostParams' => null,
+        'CountryCode' => null,
+        'EducationCode' => null,
+        'EmpType' => null,
+        'EnableCompanyCollapse' => 'true',
+        'EnableCompanyJobTitleCollapse' => null,
+        'ExcludeApplyRequirements' => null,
+        'ExcludeCompanyNames' => null,
+        'ExcludeJobTitles' => null,
+        'ExcludeKeywords' => null,
+        'ExcludeNational' => null,
+        'ExcludeNonTraditionalJobs' => null,
+        'FacetCategory' => null,
+        'FacetCompany' => null,
+        'FacetCity' => null,
+        'FacetState' => null,
+        'FacetCityState' => null,
+        'FacetPay' => null,
+        'FacetRelatedJobTitle' => null,
+        'FacetCountry' => null,
+        'FacetEmploymentType' => null,
+        'HostSite' => 'US',
+        'IncludeCompanyChildren' => null,
+        'IndustryCodes' => null,
+        'JobTitle' => null,
+        'Keywords' => null,
+        'Location' => null,
+        'NormalizedCompanyDID' => null,
+        'NormalizedCompanyDIDBoostParams' => null,
+        'NormalizedCompanyName' => null,
+        'ONetCode' => null,
+        'OrderBy' => null,
+        'OrderDirection' => null,
+        'PageNumber' => null,
+        'PartnerID' => null,
+        'PayHigh' => null,
+        'PayInfoOnly' => null,
+        'PayLow' => null,
+        'PerPage' => null,
+        'PostedWithin' => null,
+        'Radius' => null,
+        'RecordsPerGroup' => null,
+        'RelocateJobs' => null,
+        'SOCCode' => null,
+        'SchoolSiteID' => null,
+        'SearchAllCountries' => null,
+        'SearchView' => null,
+        'ShowCategories' => null,
+        'ShowApplyRequirements' => null,
+        'SingleONetSearch' => null,
+        'SiteEntity' => null,
+        'SiteID' => null,
+        'Skills' => null,
+        'SpecificEducation' => null,
+        'SpokenLanguage' => null,
+        'Tags' => null,
+        'TalentNetworkDID' => null,
+        'UrlCompressionService' => null,
+        'UseFacets' => 'true',
+    ];
 
     /**
-     * Enable Company Collapse (must be true to set count)
+     * Create new Careerbuilder jobs client.
      *
-     * @var string
+     * @param array $parameters
      */
-    protected $companyCollapse;
+    public function __construct($parameters = [])
+    {
+        parent::__construct($parameters);
+        array_walk($parameters, [$this, 'updateQuery']);
+    }
+
+    /**
+     * Magic method to handle get and set methods for properties
+     *
+     * @param  string $method
+     * @param  array  $parameters
+     *
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (isset($this->queryMap[$method], $parameters[0])) {
+            $this->updateQuery($parameters[0], $this->queryMap[$method]);
+        }
+        return parent::__call($method, $parameters);
+    }
 
     /**
      * Returns the standardized job object
@@ -41,31 +223,9 @@ class Careerbuilder extends AbstractProvider
      */
     public function createJobObject($payload = [])
     {
-        $defaults = [
-            'Company',
-            'CompanyDetailsURL',
-            'DescriptionTeaser',
-            'DID',
-            'OnetCode',
-            'ONetFriendlyTitle',
-            'EmploymentType',
-            'EducationRequired',
-            'ExperienceRequired',
-            'JobDetailsURL',
-            'Location',
-            'City',
-            'State',
-            'PostedDate',
-            'Pay',
-            'JobTitle',
-            'CompanyImageURL',
-            'Skills',
-        ];
+        $payload = static::parseAttributeDefaults($payload, $this->defaultAttributes);
 
-        $payload = static::parseAttributeDefaults($payload, $defaults);
-
-        $job = new Job(
-            [
+        $job = new Job([
             'description' => $payload['DescriptionTeaser'],
             'employmentType' => $payload['EmploymentType'],
             'title' => $payload['JobTitle'],
@@ -74,8 +234,7 @@ class Careerbuilder extends AbstractProvider
             'educationRequirements' => $payload['EducationRequired'],
             'experienceRequirements' => $payload['ExperienceRequired'],
             'sourceId' => $payload['DID'],
-            ]
-        );
+        ]);
 
         $pay = $this->parseSalariesFromString($payload['Pay']);
 
@@ -93,40 +252,10 @@ class Careerbuilder extends AbstractProvider
             ->setMaximumSalary($pay['max']);
 
         if (isset($payload['Skills']['Skill'])) {
-            $job->setSkills($this->getSkillSet($payload['Skills']['Skill']));
+            $job->setSkills($this->parseSkillSet($payload['Skills']['Skill']));
         }
 
         return $job;
-    }
-
-    /**
-     * Get host site
-     *
-     * @return string
-     */
-    public function getHostSite()
-    {
-        return 'US';
-    }
-
-    /**
-     * Get Use Facets
-     *
-     * @return string
-     */
-    public function getUseFacets()
-    {
-        return 'true';
-    }
-
-    /**
-     * Get Enable Company Collapse
-     *
-     * @return string
-     */
-    public function getCompanyCollapse()
-    {
-        return 'true';
     }
 
     /**
@@ -156,30 +285,28 @@ class Careerbuilder extends AbstractProvider
      */
     public function getQueryString()
     {
-        $queryParams = [
-            'DeveloperKey' => 'getDeveloperKey',
-            'Keywords' => 'getKeyword',
-            'FacetState' => 'getState',
-            'FacetCity' => 'getCity',
-            'PageNumber' => 'getPage',
-            'PerPage' => 'getCount',
-            'UseFacets' => 'getUseFacets',
-            'EnableCompanyCollapse' => 'getCompanyCollapse',
-        ];
+        return http_build_query($this->queryParams);
+    }
 
-        $queryString = [];
+    /**
+     * Get url
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        $queryString = $this->getQueryString();
+        return 'http://api.careerbuilder.com/v2/jobsearch/?'.$queryString;
+    }
 
-        array_walk(
-            $queryParams,
-            function ($value, $key) use (&$queryString) {
-                $computedValue = $this->$value();
-                if (!is_null($computedValue)) {
-                    $queryString[$key] = $computedValue;
-                }
-            }
-        );
-
-        return http_build_query($queryString);
+    /**
+     * Get http verb
+     *
+     * @return string
+     */
+    public function getVerb()
+    {
+        return 'GET';
     }
 
     /**
@@ -210,7 +337,12 @@ class Careerbuilder extends AbstractProvider
         return $salary;
     }
 
-    public function parseAnnualRange($salary = [], $input = null)
+    /**
+     * Parse annual salary range from CB API
+     *
+     * @return array
+     */
+    protected function parseAnnualRange($salary = [], $input = null)
     {
         preg_replace_callback("/(.\d+k)\s.\s(.\d+k)/", function ($matches) use (&$salary) {
             $salary['min'] = str_replace('k', '000', $matches[1]);
@@ -220,7 +352,12 @@ class Careerbuilder extends AbstractProvider
         return $salary;
     }
 
-    public function parseAnnualFixed($salary = [], $input = null)
+    /**
+     * Parse fixed annual salary from CB API
+     *
+     * @return array
+     */
+    protected function parseAnnualFixed($salary = [], $input = null)
     {
         preg_replace_callback("/(.\d+k)/", function ($matches) use (&$salary) {
             $salary['min'] = str_replace('k', '000', $matches[1]);
@@ -229,7 +366,12 @@ class Careerbuilder extends AbstractProvider
         return $salary;
     }
 
-    public function parseHourlyRange($salary = [], $input = null)
+    /**
+     * Parse hourly payrate range from CB API
+     *
+     * @return array
+     */
+    protected function parseHourlyRange($salary = [], $input = null)
     {
         preg_replace_callback("/(.\d+.\d+)\s.\s(.\d+.\d+)/", function ($matches) use (&$salary) {
             $salary['min'] = $matches[1];
@@ -239,7 +381,12 @@ class Careerbuilder extends AbstractProvider
         return $salary;
     }
 
-    public function parseHourlyFixed($salary = [], $input = null)
+    /**
+     * Parse fixed hourly payrate from CB API
+     *
+     * @return array
+     */
+    protected function parseHourlyFixed($salary = [], $input = null)
     {
         preg_replace_callback("/(.\d+.\d+)/", function ($matches) use (&$salary) {
             $salary['min'] = $matches[1];
@@ -249,28 +396,11 @@ class Careerbuilder extends AbstractProvider
     }
 
     /**
-     * Get url
+     * Parse skills array into string
      *
-     * @return string
+     * @return array
      */
-    public function getUrl()
-    {
-        $queryString = $this->getQueryString();
-
-        return 'http://api.careerbuilder.com/v2/jobsearch/?'.$queryString;
-    }
-
-    /**
-     * Get http verb
-     *
-     * @return string
-     */
-    public function getVerb()
-    {
-        return 'GET';
-    }
-
-    public function getSkillSet($skills)
+    protected function parseSkillSet($skills)
     {
         if (is_array($skills)) {
             return implode(', ', $skills);
@@ -278,5 +408,21 @@ class Careerbuilder extends AbstractProvider
             return $skills;
         }
         return null;
+    }
+
+    /**
+     * Attempts to update current query parameters.
+     *
+     * @param  string  $value
+     * @param  string  $key
+     *
+     * @return Careerbuilder
+     */
+    protected function updateQuery($value, $key)
+    {
+        if (array_key_exists($key, $this->queryParams)) {
+            $this->queryParams[$key] = $value;
+        }
+        return $this;
     }
 }

--- a/tests/src/CareerbuilderTest.php
+++ b/tests/src/CareerbuilderTest.php
@@ -14,18 +14,11 @@ class CareerbuilderTest extends \PHPUnit_Framework_TestCase
         $this->client = new Careerbuilder();
     }
 
-    public function testItWillUseJsonFormat()
+    public function testItWillUseXmlFormat()
     {
         $format = $this->client->getFormat();
 
         $this->assertEquals('xml', $format);
-    }
-
-    public function testItUsesUSHostSite()
-    {
-        $hostSite = $this->client->getHostSite();
-
-        $this->assertEquals('US', $hostSite);
     }
 
     public function testItWillUseGetHttpVerb()


### PR DESCRIPTION
Added support for all available parameters in the Careerbuilder job search api: https://github.com/JobBrander/jobs-careerbuilder/issues/6

Refactored url query string method and moved some of the internal methods to protected rather than public.